### PR TITLE
Fix terragrunt plan and apply new-provider error

### DIFF
--- a/.github/workflows/terragrunt-apply.yml
+++ b/.github/workflows/terragrunt-apply.yml
@@ -68,13 +68,6 @@ on:
         type: boolean
         default: false
 
-env:
-  AWS_REGION: ${{ inputs.aws_region }}
-  tofu_version: ${{ inputs.opentofu_version }}
-  tf_version: ${{ inputs.terraform_version }}
-  tg_version: ${{ inputs.terragrunt_version }}
-  working_dir: ${{ inputs.working_dir }}
-
 jobs:
   apply:
     name: Apply Terragrunt Plan File
@@ -128,7 +121,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ inputs.aws_access_key_id }}
           AWS_SECRET_ACCESS_KEY: ${{ inputs.aws_secret_access_key }}
           AWS_OIDC_ROLE_ARN: ${{ secrets.AWS_OIDC_ROLE_ARN }}
-          AWS_REGION: ${{ inputs.AWS_REGION }}
+          AWS_REGION: ${{ inputs.aws_region }}
 
       - name: Get Plan form S3
         if: ${{ inputs.use_gh_artifacts == false }}
@@ -173,12 +166,12 @@ jobs:
       - name: Terragrunt Init and Upgrade
         uses: gruntwork-io/terragrunt-action@v2
         env:
-         AWS_SHARED_CREDENTIALS_FILE: ${{ github.workspace }}/.aws/credentials
-         TF_INPUT: false
+          AWS_SHARED_CREDENTIALS_FILE: ${{ github.workspace }}/.aws/credentials
+          TF_INPUT: false
         with:
-          tf_version: ${{ env.tf_version }}
-          tg_version: ${{ env.tg_version }}
-          tg_dir: ${{ env.working_dir }}
+          tf_version: ${{ inputs.terraform_version }}
+          tg_version: ${{ inputs.terragrunt_version }}
+          tg_dir: ${{ inputs.working_dir }}
           tg_command: run-all init -upgrade
 
       - name: Terragrunt Apply
@@ -187,7 +180,7 @@ jobs:
           AWS_SHARED_CREDENTIALS_FILE: ${{ github.workspace }}/.aws/credentials
           INPUT_PRE_EXEC_1: export TERRAGRUNT_GIT_REPO_NAME=${{ github.event.repository.name }}
         with:
-          tf_version: ${{ env.tf_version }}
-          tg_version: ${{ env.tg_version }}
-          tg_dir: ${{ env.working_dir }}
+          tf_version: ${{ inputs.terraform_version }}
+          tg_version: ${{ inputs.terragrunt_version }}
+          tg_dir: ${{ inputs.working_dir }}
           tg_command: apply ${{ inputs.plan_file_name }}.plan.out

--- a/.github/workflows/terragrunt-apply.yml
+++ b/.github/workflows/terragrunt-apply.yml
@@ -170,6 +170,17 @@ jobs:
           openssl enc -d -aes-256-ctr -pbkdf2 -in ${{ inputs.working_dir }}/${{ inputs.plan_file_name }}.plan.out.enc -out ${{ inputs.working_dir }}/${{ inputs.plan_file_name }}.plan.out -pass pass:"${SECRET_ENC_KEY}"
           echo "Unencrypted Plan SHASUM: $(shasum ${{ inputs.working_dir }}${{ inputs.plan_file_name }}.plan.out)"
 
+      - name: Terragrunt Init and Upgrade
+        uses: gruntwork-io/terragrunt-action@v2
+        env:
+         AWS_SHARED_CREDENTIALS_FILE: ${{ github.workspace }}/.aws/credentials
+         TF_INPUT: false
+        with:
+          tf_version: ${{ env.tf_version }}
+          tg_version: ${{ env.tg_version }}
+          tg_dir: ${{ env.working_dir }}
+          tg_command: run-all init -upgrade
+
       - name: Terragrunt Apply
         uses: gruntwork-io/terragrunt-action@v2
         env:

--- a/.github/workflows/terragrunt-plan.yml
+++ b/.github/workflows/terragrunt-plan.yml
@@ -67,13 +67,6 @@ on:
         type: boolean
         default: false
 
-env:
-  AWS_REGION: ${{ inputs.aws_region }}
-  tofu_version: ${{ inputs.opentofu_version }}
-  tf_version: ${{ inputs.terraform_version }}
-  tg_version: ${{ inputs.terragrunt_version }}
-  working_dir: ${{ inputs.working_dir }}
-
 jobs:
   plan:
     name: Create Terragrunt Plan File
@@ -130,13 +123,13 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ inputs.aws_access_key_id }}
           AWS_SECRET_ACCESS_KEY: ${{ inputs.aws_secret_access_key }}
           AWS_OIDC_ROLE_ARN: ${{ secrets.AWS_OIDC_ROLE_ARN }}
-          AWS_REGION: ${{ inputs.AWS_REGION }}
+          AWS_REGION: ${{ inputs.aws_region }}
 
       - name: Get output file directory name
         id: output_file_name
         run: |
           export PLAN_FILE_NAME=${{ github.event.repository.name }}-${{ github.run_id }}-${{github.run_attempt}}
-          mkdir -p ${{env.working_dir}}/$PLAN_FILE_NAME
+          mkdir -p ${{inputs.working_dir}}/$PLAN_FILE_NAME
           export USERID=$(id -u)
           echo USERID=$USERID >> $GITHUB_OUTPUT
           echo PLAN_FILE_S3_PATH=${{ inputs.aws_ci_artifact_bucket_path }}/$PLAN_FILE_NAME/$PLAN_FILE_NAME >> $GITHUB_OUTPUT
@@ -148,9 +141,9 @@ jobs:
           AWS_SHARED_CREDENTIALS_FILE: ${{ github.workspace }}/.aws/credentials
           TF_INPUT: false
         with:
-          tf_version: ${{ env.tf_version }}
-          tg_version: ${{ env.tg_version }}
-          tg_dir: ${{ env.working_dir }}
+          tf_version: ${{ inputs.terraform_version }}
+          tg_version: ${{ inputs.terragrunt_version }}
+          tg_dir: ${{ inputs.working_dir }}
           tg_command: run-all init -upgrade
 
       - name: Terragrunt Plan
@@ -161,16 +154,16 @@ jobs:
           INPUT_POST_EXEC_1: sudo chown -R ${{ steps.output_file_name.outputs.USERID }}:${{ steps.output_file_name.outputs.USERID }} .
           INPUT_POST_EXEC_2: sudo chmod -R ugo+w .
         with:
-          tf_version: ${{ env.tf_version }}
-          tg_version: ${{ env.tg_version }}
-          tg_dir: ${{ env.working_dir }}
+          tf_version: ${{ inputs.terraform_version }}
+          tg_version: ${{ inputs.terragrunt_version }}
+          tg_dir: ${{ inputs.working_dir }}
           tg_command: plan -out ./${{ steps.output_file_name.outputs.PLAN_FILE_NAME }}/${{ steps.output_file_name.outputs.PLAN_FILE_NAME }}.plan.out
 
       - name: Get Plan File Path
         id: get_plan_file_path
         shell: bash
         run: |
-          find_path=$(find ${{env.working_dir}} -iname ${{ steps.output_file_name.outputs.PLAN_FILE_NAME }}.plan.out)
+          find_path=$(find ${{inputs.working_dir}} -iname ${{ steps.output_file_name.outputs.PLAN_FILE_NAME }}.plan.out)
           cp -rp $find_path ./${{ steps.output_file_name.outputs.PLAN_FILE_NAME }}.plan.out
           echo PLAN_FILE_LOCAL_PATH=$find_path >> $GITHUB_OUTPUT
 

--- a/.github/workflows/terragrunt-plan.yml
+++ b/.github/workflows/terragrunt-plan.yml
@@ -142,6 +142,17 @@ jobs:
           echo PLAN_FILE_S3_PATH=${{ inputs.aws_ci_artifact_bucket_path }}/$PLAN_FILE_NAME/$PLAN_FILE_NAME >> $GITHUB_OUTPUT
           echo PLAN_FILE_NAME=$PLAN_FILE_NAME >> $GITHUB_OUTPUT
 
+      - name: Terragrunt Init and Upgrade
+        uses: gruntwork-io/terragrunt-action@v2
+        env:
+          AWS_SHARED_CREDENTIALS_FILE: ${{ github.workspace }}/.aws/credentials
+          TF_INPUT: false
+        with:
+          tf_version: ${{ env.tf_version }}
+          tg_version: ${{ env.tg_version }}
+          tg_dir: ${{ env.working_dir }}
+          tg_command: run-all init -upgrade
+
       - name: Terragrunt Plan
         uses: gruntwork-io/terragrunt-action@v2
         env:


### PR DESCRIPTION
# Issue
- There was error when a manual change was done with terragrunt new provider. 
```
The current state of aws_ecs_service.main was created by a newer provider
version than is currently selected. Upgrade the aws provider to work with
this state.
```

# Fix
- Reinit and upgrade terraform (modules & plugins) before plan and apply