### PR TITLE
Action to export variables and secret to GITHUB_ENV

### DIFF
--- a/.github/actions/env_substitute/README.md
+++ b/.github/actions/env_substitute/README.md
@@ -1,0 +1,106 @@
+# Create .env File Action
+
+A GitHub Action to create a `.env` file from a template with environment variable substitution.
+
+## Overview
+
+This action automates the creation of a `.env` file for your application by:
+
+1. Using a template file (like `.env.example`)
+2. Substituting environment variables into the template
+3. Adding standard Git branch and tag information
+4. Supporting additional variables through JSON input
+
+## Features
+
+- Environment variable substitution with default value support (`${VAR:-default}`)
+- Handles missing template files gracefully
+- Supports custom template and output filenames
+- Configurable working directory
+- Add additional variables in JSON format
+- Uses the powerful [a8m/envsubst](https://github.com/a8m/envsubst) tool
+
+## Usage
+
+```yaml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create .env File
+        uses: hotosm/gh-workflows/.github/actions/env_substitute@main
+        with:
+          working_directory: ./frontend
+          template_dotenv: ".env.example"
+```
+
+## Inputs
+
+| Input               | Description                                   | Required | Default                  |
+| ------------------- | --------------------------------------------- | -------- | ------------------------ |
+| `working_directory` | Directory containing the .env template        | No       | `'.'`                    |
+| `template_dotenv`   | Name of the template .env file                | No       | `'.env.example'`         |
+| `output_file`       | Name of the output .env file                  | No       | `'.env'`                 |
+| `git_branch`        | Git branch to include in the .env file        | No       | `${{ github.ref_name }}` |
+| `tag_override`      | Tag override to include in the .env file      | No       | `''`                     |
+| `envsubst_version`  | Version of envsubst to use                    | No       | `'v1.2.0'`               |
+| `additional_vars`   | Additional variables to include (JSON format) | No       | `'{}'`                   |
+
+## How It Works
+
+1. Checks if the template file exists in the specified directory
+2. Downloads the specified version of `envsubst`
+3. Substitutes environment variables in the template
+4. Adds `GIT_BRANCH` and optional `TAG_OVERRIDE` to the `.env` file
+5. Adds any additional variables provided in JSON format
+
+## Example: With Additional Variables
+
+```yaml
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Load Environment Variables
+        uses: hotosm/gh-workflows/.github/actions/vars_n_secret_to_env@main
+        with:
+          vars_context: ${{ toJson(vars) }}
+          secrets_context: ${{ toJson(secrets) }}
+
+      - name: Create .env File
+        uses: hotosm/gh-workflows/.github/actions/env_substitute@main
+        with:
+          working_directory: "./frontend"
+          template_dotenv: ".env.example"
+          output_file: ".env"
+          additional_vars: '{"BUILD_ID":"${{ github.run_id }}","DEPLOY_TIME":"$(date -u +"%Y-%m-%dT%H:%M:%SZ")"}'
+```
+
+## Template File Format
+
+Your template file can contain environment variable references that will be substituted:
+
+```
+# Database configuration
+DB_HOST=${DB_HOST:-localhost}
+DB_PORT=${DB_PORT:-5432}
+DB_NAME=${DB_NAME}
+DB_USER=${DB_USER}
+DB_PASSWORD=${DB_PASSWORD}
+
+# Application settings
+APP_URL=${APP_URL:-http://localhost:3000}
+DEBUG=${DEBUG:-false}
+```
+
+## Requirements
+
+- This action requires `curl` and `jq`, which are pre-installed on GitHub-hosted runners.
+
+## License
+
+This project is licensed under the MIT License.

--- a/.github/actions/env_substitute/action.yml
+++ b/.github/actions/env_substitute/action.yml
@@ -1,0 +1,79 @@
+name: Create .env File
+description: Create a .env file from a template with environment variable substitution
+
+inputs:
+  working_directory:
+    description: 'Directory containing the .env template'
+    required: false
+    default: '.'
+  template_dotenv:
+    description: 'Name of the template .env file'
+    required: false
+    default: '.env.example'
+  output_file:
+    description: 'Name of the output .env file'
+    required: false
+    default: '.env'
+  git_branch:
+    description: 'Git branch to include in the .env file'
+    required: false
+    default: ${{ github.ref_name }}
+  tag_override:
+    description: 'Tag override to include in the .env file'
+    required: false
+    default: ''
+  envsubst_version:
+    description: 'Version of envsubst to use'
+    required: false
+    default: 'v1.2.0'
+  additional_vars:
+    description: 'Additional variables to include in .env file (JSON format: {"KEY1":"value1","KEY2":"value2"})'
+    required: false
+    default: '{}'
+
+runs:
+  using: composite
+  steps:
+    - name: Create ${{ inputs.output_file }} file
+      shell: bash
+      env:
+        TEMPLATE_DOTENV: ${{ inputs.template_dotenv }}
+        GIT_BRANCH: ${{ inputs.git_branch }}
+        TAG_OVERRIDE: ${{ inputs.tag_override }}
+        ENVSUBST_VERSION: ${{ inputs.envsubst_version }}
+        ADDITIONAL_VARS: ${{ inputs.additional_vars }}
+        OUTPUT_FILE: ${{ inputs.output_file }}
+      working-directory: ${{ inputs.working_directory }}
+      run: |
+        echo "Checking if ${TEMPLATE_DOTENV} exists"
+        if [ -f "${TEMPLATE_DOTENV}" ]; then
+          # Get a8m/envsubst (required for default vals syntax ${VAR:-default})
+          echo "Downloading envsubst ${ENVSUBST_VERSION}"
+          curl -L https://github.com/a8m/envsubst/releases/download/${ENVSUBST_VERSION}/envsubst-`uname -s`-`uname -m` -o envsubst
+          if [ $? -ne 0 ]; then
+            echo "Failed to download envsubst"
+            exit 1
+          fi
+          chmod +x envsubst
+          
+          echo "Substituting variables from ${TEMPLATE_DOTENV} --> ${OUTPUT_FILE}"
+          ./envsubst < "${TEMPLATE_DOTENV}" > ${OUTPUT_FILE}
+        else
+          echo "${TEMPLATE_DOTENV} not found, creating empty ${OUTPUT_FILE}"
+          touch ${OUTPUT_FILE}
+        fi
+        
+        # Add standard variables
+        echo "GIT_BRANCH=${GIT_BRANCH}" >> ${OUTPUT_FILE}
+        if [ -n "${TAG_OVERRIDE}" ]; then
+          echo "TAG_OVERRIDE=${TAG_OVERRIDE}" >> ${OUTPUT_FILE}
+        fi
+        
+        # Add additional variables if provided
+        if [ "${ADDITIONAL_VARS}" != "{}" ]; then
+          echo "Adding additional variables to ${OUTPUT_FILE}"
+          echo "${ADDITIONAL_VARS}" | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> ${OUTPUT_FILE}
+        fi
+        
+        echo "Created ${OUTPUT_FILE} file with contents:"
+        

--- a/.github/actions/vars_n_secret_to_env/README.md
+++ b/.github/actions/vars_n_secret_to_env/README.md
@@ -1,0 +1,86 @@
+# Load Environment Variables Action
+
+A GitHub Action to load environment variables from GitHub variables & secrets contexts and parse nested variables.
+
+## Overview
+
+This action simplifies the process of making GitHub variables and secrets available as environment variables within your workflow, including parsing nested variables like `FRONTEND_ENV_VARS` that contain multiple key-value pairs.
+
+## Features
+
+- Load variables from GitHub `vars` context
+- Load secrets from GitHub `secrets` context
+- Parse and extract nested variables that contain multiple key-value pairs
+- Handle multiline strings properly
+- Support for Git branch and tag override variables
+
+## Usage
+
+```yaml
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Load Environment Variables
+        uses: hotosm/gh-workflows/.github/actions/vars_n_secret_to_env@main
+        with:
+          vars_context: ${{ toJson(vars) }}
+          secrets_context: ${{ toJson(secrets) }}
+```
+
+## Inputs
+
+| Input               | Description                                     | Required | Default                  |
+| ------------------- | ----------------------------------------------- | -------- | ------------------------ |
+| `git_branch`        | The Git branch name                             | No       | `${{ github.ref_name }}` |
+| `tag_override`      | Optional tag override                           | No       | `''`                     |
+| `vars_context`      | JSON string of variables context                | Yes      | -                        |
+| `secrets_context`   | JSON string of secrets context                  | Yes      | -                        |
+| `parse_nested_vars` | Parse nested variables (like FRONTEND_ENV_VARS) | No       | `'true'`                 |
+
+## How It Works
+
+1. The action uses `jq` to parse the JSON contexts and extract all variables and secrets.
+2. It exports each value to `$GITHUB_ENV` using GitHub's multiline variable format.
+3. If `parse_nested_vars` is set to `true`, it will look for and parse nested variables like `FRONTEND_ENV_VARS` that contain multiple key-value pairs.
+4. Always adds `GIT_BRANCH` and optionally `TAG_OVERRIDE` to the environment.
+
+## Example: Parse Nested Variables
+
+If you have a GitHub variable called `FRONTEND_ENV_VARS` with content like:
+
+```
+TM_APP_BASE_URL=https://tasks-stage.hotosm.org
+TM_API_BASE_URL=https://tasking-manager-staging-api.hotosm.org/api
+```
+
+This action will parse it and make both `TM_APP_BASE_URL` and `TM_API_BASE_URL` available as separate environment variables in subsequent steps.
+
+## Advanced Example
+
+```yaml
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Load Environment Variables
+        uses: hotosm/gh-workflows/.github/actions/vars_n_secret_to_env@main
+        with:
+          vars_context: ${{ toJson(vars) }}
+          secrets_context: ${{ toJson(secrets) }}
+          tag_override: ${{ inputs.version_tag }}
+          parse_nested_vars: "true"
+
+      - name: Use Environment Variables
+        run: |
+          echo "Building for environment: $TM_APP_BASE_URL"
+          echo "Using branch: $GIT_BRANCH"
+```
+
+## Requirements
+
+- The workflow must have access to `jq`, which is pre-installed on GitHub-hosted runners.

--- a/.github/actions/vars_n_secret_to_env/action.yml
+++ b/.github/actions/vars_n_secret_to_env/action.yml
@@ -1,0 +1,79 @@
+name: Load Environment Variables
+description: Load environment variables from GitHub variables & secrets and parse nested variables
+
+inputs:
+  git_branch:
+    description: 'The Git branch name'
+    required: false
+    default: ${{ github.ref_name }}
+  tag_override:
+    description: 'Optional tag override'
+    required: false
+    default: ''
+  vars_context:
+    description: 'JSON string of variables context'
+    required: true
+  secrets_context:
+    description: 'JSON string of secrets context'
+    required: true
+  parse_nested_vars:
+    description: 'Parse nested variables (like FRONTEND_ENV_VARS)'
+    required: false
+    default: 'true'
+
+runs:
+  using: composite
+  steps:
+    - name: Load Environment Variables
+      shell: bash
+      env:
+        GIT_BRANCH: ${{ inputs.git_branch }}
+        TAG_OVERRIDE: ${{ inputs.tag_override }}
+        VARS_CONTEXT: ${{ inputs.vars_context }}
+        SECRETS_CONTEXT: ${{ inputs.secrets_context }}
+        PARSE_NESTED: ${{ inputs.parse_nested_vars }}
+      run: |
+        # Random delimiter string for security
+        delim=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+        
+        # Parse JSON with multiline strings, using delimiter (Github specific)
+        to_envs() { 
+          jq -r "to_entries[] | \"\(.key)<<$delim\n\(.value)\n$delim\n\""
+        }
+        
+        # Set branch and tag to env
+        echo "GIT_BRANCH=${GIT_BRANCH}" >> $GITHUB_ENV
+        if [ -n "${TAG_OVERRIDE}" ]; then
+          echo "TAG_OVERRIDE=${TAG_OVERRIDE}" >> $GITHUB_ENV
+        fi
+        
+        # Set VARS_CONTEXT if not null
+        if [ "${VARS_CONTEXT}" != "null" ]; then
+          echo "${VARS_CONTEXT}" | to_envs >> $GITHUB_ENV
+          
+          # Parse nested variables if enabled
+          if [ "${PARSE_NESTED}" = "true" ]; then
+            # Extract and parse FRONTEND_ENV_VARS from VARS_CONTEXT if it exists
+            FRONTEND_VARS=$(echo "${VARS_CONTEXT}" | jq -r '.FRONTEND_ENV_VARS // ""')
+            if [ -n "$FRONTEND_VARS" ]; then
+              # Split the string by newlines and export each variable
+              echo "$FRONTEND_VARS" | grep -v '^\*\*\*$' | while IFS= read -r line || [[ -n "$line" ]]; do
+                # Skip empty lines
+                [ -z "$line" ] && continue
+                
+                # If line contains '=', export it as an env var
+                if [[ "$line" == *"="* ]]; then
+                  key=$(echo "$line" | cut -d= -f1)
+                  value=$(echo "$line" | cut -d= -f2-)
+                  echo "$key=$value" >> $GITHUB_ENV
+                fi
+              done
+            fi
+          fi
+        fi
+        
+        # Set SECRETS_CONTEXT if not null
+        if [ "${SECRETS_CONTEXT}" != "null" ]; then
+          echo "${SECRETS_CONTEXT}" | to_envs >> $GITHUB_ENV
+        fi
+        


### PR DESCRIPTION
# Action to export GH vars and secret to GH_ENV and substitute it into template env file.
- Action derived from existing GH workflow (image_build, compose_deploy etc.)

## USAGE:
```yaml
jobs:
  deploy:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v3
      - name: Load Environment Variables
        uses: hotosm/gh-workflows/.github/actions/vars_n_secret_to_env@main
        with:
          vars_context: ${{ toJson(vars) }}
          secrets_context: ${{ toJson(secrets) }}
      - name: Create .env File
        uses: hotosm/gh-workflows/.github/actions/env_substitute@main
        with:
          working_directory: "./frontend"
          template_dotenv: ".env.example"
          output_file: ".env"
```