### PR TITLE
Fix: Allow e2e workflow to run correctly on forked repos

### DIFF
--- a/.github/workflows/test_compose.yml
+++ b/.github/workflows/test_compose.yml
@@ -272,7 +272,7 @@ jobs:
         run: |
           ${{ inputs.pre_command }}
 
-          docker compose --file ${{ inputs.compose_file }} \
+          DEBUG_OVERRIDE=${{DEBUG_OVERRIDE}} compose --file ${{ inputs.compose_file }} \
             run --no-TTY \
             ${{ inputs.compose_service }} ${{ inputs.compose_command }}
 

--- a/.github/workflows/test_compose.yml
+++ b/.github/workflows/test_compose.yml
@@ -272,7 +272,7 @@ jobs:
         run: |
           ${{ inputs.pre_command }}
 
-          DEBUG_OVERRIDE=${{DEBUG_OVERRIDE}} compose --file ${{ inputs.compose_file }} \
+          DEBUG_OVERRIDE=${{DEBUG_OVERRIDE}} docker compose --file ${{ inputs.compose_file }} \
             run --no-TTY \
             ${{ inputs.compose_service }} ${{ inputs.compose_command }}
 


### PR DESCRIPTION
Fix for [issue 1775](https://github.com/hotosm/fmtm/issues/1775).