### PR TITLE
Revert "Fix: Allow e2e workflow to run correctly on forked repos"

### DIFF
--- a/.github/workflows/test_compose.yml
+++ b/.github/workflows/test_compose.yml
@@ -272,7 +272,7 @@ jobs:
         run: |
           ${{ inputs.pre_command }}
 
-          DEBUG_OVERRIDE=${{DEBUG_OVERRIDE}} docker compose --file ${{ inputs.compose_file }} \
+          docker compose --file ${{ inputs.compose_file }} \
             run --no-TTY \
             ${{ inputs.compose_service }} ${{ inputs.compose_command }}
 


### PR DESCRIPTION
Reverts hotosm/gh-workflows#70

@spwoodcock this is causing an issue with the github action. let's revert for now.
[https://github.com/hotosm/fmtm/actions/runs/15779401574](https://github.com/hotosm/fmtm/actions/runs/15779401574)
