### PR TITLE
Fix issue 1775: Allow e2e workflow to run correctly

### DIFF
--- a/.github/workflows/test_compose.yml
+++ b/.github/workflows/test_compose.yml
@@ -82,6 +82,11 @@ on:
         required: false
         type: string
         default: "test"
+      debug_override:
+        description: "Allow overriding the DEBUG environment variable in the compose file."
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: write
@@ -272,7 +277,7 @@ jobs:
         run: |
           ${{ inputs.pre_command }}
 
-          DEBUG_OVERRIDE=${{DEBUG_OVERRIDE}} docker compose --file ${{ inputs.compose_file }} \
+          DEBUG_OVERRIDE=${{inputs.debug_override}} docker compose --file ${{ inputs.compose_file }} \
             run --no-TTY \
             ${{ inputs.compose_service }} ${{ inputs.compose_command }}
 


### PR DESCRIPTION
Added `debug_override` input variable on _.github/workflows/test_compose.yml_ to allow overriding the DEBUG environment variable in the compose file.
This is aimed to fix [Allow e2e workflow to run correctly on forked repos](https://github.com/hotosm/fmtm/issues/1775).